### PR TITLE
Warden ubuntu etcd patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,31 @@ bosh upload release https://bosh.io/d/github.com/cloudfoundry-community/route-re
 bosh upload release https://bosh.io/d/github.com/cloudfoundry-community/simple-remote-syslog-boshrelease
 ```
 
+Get the necessary submodules:
+
+```
+git submodule update --init --recursive --force
+```
+
 To use your own etcd cluster:
 
 ```
 ./templates/make_manifest warden upstream templates/services-cluster.yml tmp/etcd.yml
-bosh deploy
 ```
 
 To deploy a simple one-node etcd cluster for demonstration purposes:
 
 ```
 ./templates/make_manifest warden upstream templates/services-cluster.yml templates/jobs-etcd.yml
+```
+
+Upload a Dingo PostgreSQL Release and deploy:
+
+```
+bosh create release --force && bosh upload release
 bosh deploy
 ```
+
 
 ### ETCD cluster
 

--- a/templates/make_manifest
+++ b/templates/make_manifest
@@ -2,7 +2,7 @@
 
 infrastructure=$1; shift
 docker_image=$1; shift
-set -e
+set -e -x
 
 template_prefix="dingo-postgresql"
 STEMCELL_OS=${STEMCELL_OS:-ubuntu}
@@ -38,6 +38,10 @@ else
   DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-demo}
 fi
 
+if [[ "$DIRECTOR_CPI" == "warden_cpi" ]]; then
+  DIRECTOR_CPI="warden"
+fi
+
 if [[ $DIRECTOR_NAME = "Bosh Lite Director" ]]; then
   if [[ $infrastructure != "garden" || $infrastructure != "warden" ]]; then
     echo "Not targeting bosh-lite with garden/warden CPI. Please use 'bosh target' before running this script."
@@ -61,7 +65,14 @@ STEMCELL=${STEMCELL:-$(latest_uploaded_stemcell)}
 if [[ "${STEMCELL}X" == "X" ]]; then
   echo
   echo "Uploading latest $DIRECTOR_CPI/$STEMCELL_OS stemcell..."
-  STEMCELL_URL=$(bosh public stemcells --full | grep $DIRECTOR_CPI | grep $STEMCELL_OS | sort -nr | head -n1 | awk '{ print $4 }')
+
+  if [[ "${DIRECTOR_CPI}" = "warden" && "${STEMCELL_OS}" = "ubuntu" ]]; then
+    echo "Adding hint to go after Trusty and not Lucid"
+    STEMCELL_URL=$(bosh public stemcells --full | grep $DIRECTOR_CPI | grep $STEMCELL_OS | grep "trusty" | sort -nr | head -n1 | awk '{ print $4 }')
+  else
+    STEMCELL_URL=$(bosh public stemcells --full | grep $DIRECTOR_CPI | grep $STEMCELL_OS | sort -nr | head -n1 | awk '{ print $4 }')
+  fi
+
   bosh upload stemcell $STEMCELL_URL
 fi
 STEMCELL=${STEMCELL:-$(latest_uploaded_stemcell)}

--- a/templates/make_manifest
+++ b/templates/make_manifest
@@ -2,7 +2,7 @@
 
 infrastructure=$1; shift
 docker_image=$1; shift
-set -e -x
+set -e
 
 template_prefix="dingo-postgresql"
 STEMCELL_OS=${STEMCELL_OS:-ubuntu}


### PR DESCRIPTION
Added patch to for $DIRECTOR_CPI returning "warden_cpi" which doesn't string match to public bosh stemcells.

Defaulting to "Trusty" stemcells to download instead of "Lucid" which I don't think are supported anymore.

Added notes to readme about uploading the release which may not have been obvious to all readers.
