### PR TITLE
test that cells are allocated to diff AZs

### DIFF
--- a/ci/tasks/create-manifest.sh
+++ b/ci/tasks/create-manifest.sh
@@ -34,6 +34,14 @@ releases:
   version: ${simple_remote_syslog_version}
 EOF
 
+cat > tmp/scale.yml <<EOF
+jobs:
+- name: cell_z1
+  instances: 2
+- name: cell_z2
+  instances: 2
+EOF
+
 cat > tmp/syslog.yml <<EOF
 properties:
   remote_syslog:
@@ -89,7 +97,7 @@ bosh target ${bosh_target}
 export DEPLOYMENT_NAME=${deployment_name}
 ./templates/make_manifest warden ${docker_image_source} ${services_template} \
   templates/jobs-etcd.yml tmp/syslog.yml tmp/docker_image.yml tmp/backups.yml \
-  tmp/releases.yml tmp/cf-disaster-recovery.yml
+  tmp/scale.yml tmp/releases.yml tmp/cf-disaster-recovery.yml
 
 cp tmp/${DEPLOYMENT_NAME}*.yml ${manifest_dir}/manifest.yml
 

--- a/jobs/sanity-test/spec
+++ b/jobs/sanity-test/spec
@@ -4,6 +4,7 @@ packages: [jq, postgresql-9.4]
 templates:
   bin/run: bin/run
   bin/create-service: bin/create-service
+  bin/test-cell-allocation: bin/test-cell-allocation
   bin/test-storage: bin/test-storage
   bin/test-replication: bin/test-replication
   bin/test-failure-recovery: bin/test-failure-recovery

--- a/jobs/sanity-test/templates/bin/run
+++ b/jobs/sanity-test/templates/bin/run
@@ -30,8 +30,11 @@ for plan_id in ${plan_ids[@]}; do
   uri=$(echo $credentials | jq -r ".credentials.uri")
   superuser_uri=$(echo $credentials | jq -r ".credentials.superuser_uri")
 
+  test-cell-allocation $instance_id
+
   echo Giving HAPROXY some time
   sleep 10
+
   test-storage $uri
   test-replication $instance_id
   test-failure-recovery $service_id $plan_id $instance_id $binding_id $uri $superuser_uri

--- a/jobs/sanity-test/templates/bin/test-cell-allocation
+++ b/jobs/sanity-test/templates/bin/test-cell-allocation
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+
+instance_id=$1
+
+echo Testing that nodes allocated to cells in different AZs
+
+node1_cell_id=$(curl ${BROKER_URI}/admin/service_instances/${instance_id} -s | jq -r ".nodes[0].backend_id")
+node2_cell_id=$(curl ${BROKER_URI}/admin/service_instances/${instance_id} -s | jq -r ".nodes[1].backend_id")
+
+node1_az=$(curl ${BROKER_URI}/admin/cells -s | jq -r ".[] | select(.guid == \"$node1_cell_id\") | .availability_zone")
+node2_az=$(curl ${BROKER_URI}/admin/cells -s | jq -r ".[] | select(.guid == \"$node2_cell_id\") | .availability_zone")
+
+if [[ "${node1_az}" == "${node2_az}" ]]; then
+  echo "The two nodes should not be scheduled into the same AZ: ${node1_az}"
+  exit 1
+fi


### PR DESCRIPTION
Currently this new test fails when you have 2 cells per AZ @bodymindarts 

Currently `sanity-test` error looks like:

```
+ echo Testing that nodes allocated to cells in different AZs
Testing that nodes allocated to cells in different AZs
++ jq -r '.nodes[0].backend_id'
++ curl http://starkandwayne:starkandwayne@10.244.21.2:8889/admin/service_instances/T-3894548641 -s
+ node1_cell_id=10.244.21.7
++ curl http://starkandwayne:starkandwayne@10.244.21.2:8889/admin/service_instances/T-3894548641 -s
++ jq -r '.nodes[1].backend_id'
+ node2_cell_id=10.244.21.8
++ curl http://starkandwayne:starkandwayne@10.244.21.2:8889/admin/cells -s
++ jq -r '.[] | select(.guid == "10.244.21.7") | .availability_zone'
+ node1_az=z1
++ curl http://starkandwayne:starkandwayne@10.244.21.2:8889/admin/cells -s
++ jq -r '.[] | select(.guid == "10.244.21.8") | .availability_zone'
+ node2_az=z1
+ [[ z1 == \z\1 ]]
+ echo 'The two nodes should not be scheduled into the same AZ: z1'
The two nodes should not be scheduled into the same AZ: z1
+ exit 1
```
